### PR TITLE
Oauth signature method HMAC-SHA256

### DIFF
--- a/src/nscabinet.js
+++ b/src/nscabinet.js
@@ -169,6 +169,7 @@ function _requestOpts (params) {
 
     if (params.token) {
         options.oauth = {
+            signature_method: 'HMAC-SHA256',
             consumer_key: params.consumerKey,
             consumer_secret: params.consumerSecret,
             token: params.token,


### PR DESCRIPTION
Netsuite 2021.1 dropped support for HMAC-SHA1 in Token-Based Authentication. RESTlet access response is `The request could not be understood by the server due to malformed syntax.`.